### PR TITLE
Allow using AWS_PROFILE env variable in combination with ~/.aws/config

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -41,7 +41,7 @@ func SetAwsConfig(region, profile *string, role *string) (err error) {
 
 func setAwsConfig(region, profile *string, role *string) {
 	log.WithFields(log.Fields{"region": aws.StringValue(region), "profile": aws.StringValue(profile)}).Debug("Configure AWS")
-	config := &aws.Config{Region: region}
+	config := aws.Config{Region: region}
 
 	// if a profile is supplied then just use the shared credentials provider
 	// as per docs this will look in $HOME/.aws/credentials if the filename is ""
@@ -52,11 +52,16 @@ func setAwsConfig(region, profile *string, role *string) {
 	// Are we assuming a role?
 	if aws.StringValue(role) != "" {
 		// Must request credentials from STS service and replace before passing on
-		sess := session.Must(session.NewSession(config))
+		sts_sess := session.Must(session.NewSession(&config))
 		log.WithFields(log.Fields{"role": aws.StringValue(role)}).Debug("AssumeRole")
-		config.Credentials = stscreds.NewCredentials(sess, *role)
+		config.Credentials = stscreds.NewCredentials(sts_sess, *role)
 	}
 
-	SetDynamoDBConfig(config)
-	SetKMSConfig(config)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Config:            config,
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	SetDynamoDBSession(sess)
+	SetKMSSession(sess)
 }

--- a/ds.go
+++ b/ds.go
@@ -52,6 +52,10 @@ func SetDynamoDBConfig(config *aws.Config) {
 	dynamoSvc = dynamodb.New(session.New(), config)
 }
 
+func SetDynamoDBSession(sess *session.Session) {
+	dynamoSvc = dynamodb.New(sess)
+}
+
 // Credential managed credential information
 type Credential struct {
 	Name      string `dynamodbav:"name"`

--- a/kms.go
+++ b/kms.go
@@ -18,6 +18,10 @@ func SetKMSConfig(config *aws.Config) {
 	kmsSvc = kms.New(session.New(), config)
 }
 
+func SetKMSSession(sess *session.Session) {
+	kmsSvc = kms.New(sess)
+}
+
 // DataKey which contains the details of the KMS key
 type DataKey struct {
 	CiphertextBlob []byte


### PR DESCRIPTION
Similar to #65 and #70, this change allows users to use standard AWS
command line flags.

example:

    AWS_PROFILE=profile-name unicreds list

would work the same as

https://github.com/Versent/unicreds/pull/76
    unicreds --profile profile-name list